### PR TITLE
deploy fixes

### DIFF
--- a/angularmvc/angularmvc.csproj
+++ b/angularmvc/angularmvc.csproj
@@ -192,6 +192,9 @@
     <Content Include="app\components\todolist\todolist.component.html" />
     <None Include="readme.md" />
     <Content Include="rollup-config.js" />
+	<Content Include="node_modules/core-js/client/shim.min.js"/>
+	<Content Include="node_modules/zone.js/dist/zone.js"/>
+	<Content Include="dist/build.js"/>
     <Content Include="systemjs.config.js" />
     <Content Include="Scripts\bootstrap.js" />
     <Content Include="Scripts\bootstrap.min.js" />

--- a/angularmvc/angularmvc.csproj
+++ b/angularmvc/angularmvc.csproj
@@ -315,6 +315,7 @@
   </Target>
   <Target Name="BeforeBuild" Condition=" $(Configuration) == 'Release'" >
 	<Exec Command="npm install" />
+	<Exec Command="npm run build:aot"/>
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/angularmvc/angularmvc.csproj
+++ b/angularmvc/angularmvc.csproj
@@ -26,7 +26,7 @@
     <UseGlobalApplicationHostFile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
-    <TypeScriptToolsVersion>2.0</TypeScriptToolsVersion>
+    <TypeScriptToolsVersion>2.1</TypeScriptToolsVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>


### PR DESCRIPTION
[NOTE] this however will **STILL** not work on azure (at least during my tests)
it should in theory....but I discover a bug in **tsc.exe** `version 2.0.6` running on windows server

I added missing files, it looks like you are referencing them in `index.html` but they are not being copied to publish directory. Nonetheless, I don't think this is the **best practice**: copying from `node_modules` feels wrong when you are using module bundler like `rollup` (although I had limited experience on web dev)

if possible you can try using `typescript` without msbuild, it not difficult.
I will let you know if we have any updates on the `tsc.exe` issue